### PR TITLE
feat: enable optimizer to reduce contract size

### DIFF
--- a/packages/contracts/foundry.toml
+++ b/packages/contracts/foundry.toml
@@ -2,8 +2,8 @@
 solc_version = "0.8.24"
 ffi = false
 fuzz_runs = 256
-# optimizer = true
-# optimizer_runs = 3000
+optimizer = true
+optimizer_runs = 20
 verbosity = 2
 src = "src"
 test = "test"


### PR DESCRIPTION
Currently the contracts bytecode size is too large to deploy locally, or on most EVM networks, enabling the optimizer with low runs fixes this. 